### PR TITLE
Delete redundant highlight.js link

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@ Released   : 20140309
 <link href="default.css" rel="stylesheet" type="text/css" media="all" />
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/styles/default.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/languages/go.min.js">
 </head>
 <body>
 <div id="wrapper">


### PR DESCRIPTION
Same highlight.js link to Go highlighting in `<head>` and before the end of the `body`, deleted the former.
